### PR TITLE
(add): Adding ability to read from unnamed register for JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ require("nvim-quicktype").setup({
     telemetry = "disable", -- Send telemetry data to Quicktype (can be "enable", or "disable")
     output_file = nil, -- Output file (if not specified, output is printed to stdout)
     debug_dir = nil, -- Directory to write debug info to (if not specified, no debug info is written)
+    clipboard_source_register = nil, -- Register from which to read the copied JSON (if not specified, if will default to system then to unnamed and lastly to 0 register)
   },
   filetypes = {
     -- Quicktype language-specific options

--- a/doc/nvim-quicktype.txt
+++ b/doc/nvim-quicktype.txt
@@ -30,6 +30,7 @@ require("nvim-quicktype").setup({
     telemetry = "disable", -- Send telemetry data to Quicktype (can be "enable", or "disable")
     output_file = nil, -- Output file (if not specified, output is printed to stdout)
     debug_dir = nil, -- Directory to write debug info to (if not specified, no debug info is written)
+    clipboard_source_register = nil, -- Register from which to read the copied JSON (if not specified, if will default to system then to unnamed and lastly to 0 register)
   },
   cmd = "quicktype", -- Path to the quicktype executable
   filetypes = {

--- a/lua/nvim-quicktype.lua
+++ b/lua/nvim-quicktype.lua
@@ -14,6 +14,7 @@ local module = require("nvim-quicktype.module")
 ---@field alphabetize_properties boolean
 ---@field telemetry string
 ---@field debug_dir string|nil
+---@field clipboard_source_register string|nil
 
 ---@class Config
 local config = {
@@ -26,6 +27,7 @@ local config = {
     alphabetize_properties = false,
     telemetry = "disable",
     debug_dir = nil,
+    clipboard_source_register = nil
   },
   filetypes = {
     typescript = { lang = "ts", additional_options = {

--- a/lua/nvim-quicktype/module.lua
+++ b/lua/nvim-quicktype/module.lua
@@ -78,7 +78,12 @@ local function is_valid_json(str)
   return success
 end
 
-local function get_json_str_from_reg()
+local function get_json_str_from_reg(clipboard_source_register)
+  -- If clipboard_source_register is set, get the JSON from that register
+  if clipboard_source_register then
+    return vim.fn.getreg(clipboard_source_register)
+  end
+
   -- Try to get JSON from the "+" (system) register first
   local json_str = vim.fn.getreg("+")
   if json_str == "" then
@@ -94,7 +99,7 @@ end
 
 M.generate_type = function(config)
   -- Get the JSON string from the register
-  local json_str = get_json_str_from_reg()
+  local json_str = get_json_str_from_reg(config.global.clipboard_source_register)
   -- Check if the string is valid JSON
   if not is_valid_json(json_str) then
     vim.notify("The clipboard content is not valid JSON.", vim.log.levels.ERROR)

--- a/lua/nvim-quicktype/module.lua
+++ b/lua/nvim-quicktype/module.lua
@@ -86,12 +86,13 @@ local function get_json_str_from_reg(clipboard_source_register)
 
   -- Try to get JSON from the "+" (system) register first
   local json_str = vim.fn.getreg("+")
-  if json_str == "" then
-    -- Try to get JSON from the '"' (unnamed) register
-    json_str = vim.fn.getreg('"')
-    if json_str ~= "" then
-      return json_str
-    end
+  if json_str ~= "" then
+    return json_str
+  end
+  -- Try to get JSON from the '"' (unnamed) register
+  json_str = vim.fn.getreg('"')
+  if json_str ~= "" then
+    return json_str
   end
   --  Fallback to the "0" register
   return vim.fn.getreg("0")


### PR DESCRIPTION
## Description
- this PR is adding ability to read from the unnamed register as well in the next order:
  - firstly checking system register (clipboard)
  - then checking default vim(nvim) register (b/c some users are using separated registers - like me 😄 )
  - then defaulting to 0 register
 
 - config updated to allow providing the desired register to read from