### PR TITLE
fix(clipboard): Clipboard lookup fix

### DIFF
--- a/lua/nvim-quicktype/module.lua
+++ b/lua/nvim-quicktype/module.lua
@@ -86,12 +86,12 @@ local function get_json_str_from_reg(clipboard_source_register)
 
   -- Try to get JSON from the "+" (system) register first
   local json_str = vim.fn.getreg("+")
-  if json_str ~= "" then
+  if json_str ~= "" and is_valid_json(json_str) then
     return json_str
   end
   -- Try to get JSON from the '"' (unnamed) register
   json_str = vim.fn.getreg('"')
-  if json_str ~= "" then
+  if json_str ~= "" and is_valid_json(json_str) then
     return json_str
   end
   --  Fallback to the "0" register


### PR DESCRIPTION
## Description
- if the preferred register for the clipboard is not set, we need to check if the content in the register is valid JSON, so that we allow reading from all defined (system reg, then unnamed then 0), if any of those have the valid JSON we use it.